### PR TITLE
Change rule transform to insert if missing

### DIFF
--- a/src/applicationhost.xdt
+++ b/src/applicationhost.xdt
@@ -15,7 +15,7 @@
             </httpProtocol>
             <rewrite xdt:Transform="InsertIfMissing">
                 <rules xdt:Transform="InsertIfMissing" lockElements="clear">
-                    <rule name="redirect HTTP to HTTPS" enabled="true" stopProcessing="true" lockItem="true">
+                    <rule name="redirect HTTP to HTTPS" enabled="true" stopProcessing="true" lockItem="true" xdt:Transform="InsertIfMissing" xdt:Locator="Match(name)">
                         <match url="(.*)" />
                         <conditions>
                             <add input="{HTTPS}" pattern="off" ignoreCase="true" />


### PR DESCRIPTION
This way, existing rules called "redirect HTTP to HTTPS" will take precedent and prevents a duplicate rule from being added in the case that one by the same name already exists.